### PR TITLE
changing docker tag

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -36,7 +36,7 @@ deployment:
     owner: premkit
     commands:
       - cd $HOME/src/github.com/premkit/premkit && make build_docker
-      - cd $HOME/src/github.com/premkit/premkit && PREMKIT_TAG=0.1.3 make package_docker
+      - cd $HOME/src/github.com/premkit/premkit && PREMKIT_TAG=1.0.0 make package_docker
       - sudo docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - sudo docker tag -f premkit/premkit:$PREMKIT_TAG premkit/premkit:latest
       - sudo docker push premkit/premkit:$PREMKIT_TAG


### PR DESCRIPTION
Not sure why we manually override the `DOCKER_TAG` var in the deploy section, since it's up top, but I updated it