### PR TITLE
Fix cves [ch4744]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7
+FROM golang:1.9
 
 RUN go get github.com/kardianos/govendor
 RUN go get github.com/go-swagger/go-swagger/cmd/swagger

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,14 @@ build_docker:
 		--ldflags '-extldflags "-static"' \
 		-o ./deploy/bin/premkit .
 
+build_docker_local:
+	mkdir -p ./deploy/bin
+	docker run --rm -it \
+		-v `pwd`:/go/src/github.com/premkit/premkit \
+		premkit/premkit:build go build \
+			--ldflags '-extldflags "-static"' \
+			-o ./deploy/bin/premkit .
+
 package_docker:
 	docker build --rm=false -t premkit/premkit:$(PREMKIT_TAG) -f ./deploy/Dockerfile .
 

--- a/deploy/Dockerfile-build
+++ b/deploy/Dockerfile-build
@@ -1,4 +1,4 @@
-FROM golang:1.7-alpine
+FROM golang:1.9-alpine
 
 RUN apk update && apk add --no-cache \
     gcc \


### PR DESCRIPTION
This is really just to trigger a new image build. This pr will also upgrade build to golang 1.9 cause circleci defaults to that version anyway.