### PR TITLE
fix cves

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ default_env: &default_env
 
 docker_build: &docker_build
   docker:
-    - image: cimg/go:1.16
+    - image: cimg/go:1.19
   environment:
     <<: *default_env
 
@@ -45,7 +45,7 @@ jobs:
       - run:
           name: Build Swagger Spec
           command: |
-            go get github.com/go-swagger/go-swagger/cmd/swagger
+            go install github.com/go-swagger/go-swagger/cmd/swagger@latest
             make swagger_spec
       - persist_to_workspace:
           root: .

--- a/go.mod
+++ b/go.mod
@@ -1,32 +1,37 @@
 module github.com/premkit/premkit
 
-go 1.16
+go 1.17
+
+require (
+	github.com/Sirupsen/logrus v0.10.1-0.20160601113210-f3cfb454f4c2
+	github.com/boltdb/bolt v1.3.1-0.20170131192018-e9cf4fae01b5
+	github.com/gorilla/mux v0.0.0-20160605233521-9fa818a44c2b
+	github.com/hashicorp/go-cleanhttp v0.5.0
+	github.com/parnurzeal/gorequest v0.2.14-0.20160312085432-c4a74a6708c9
+	github.com/spf13/cobra v0.0.0-20160708202402-a272c3cbd5ff
+	github.com/spf13/viper v0.0.0-20160605220307-c1ccc378a054
+	github.com/stretchr/testify v1.2.3-0.20181014000028-04af85275a5c
+	github.com/vulcand/oxy v0.0.0-20160623194703-40720199a16c
+)
 
 require (
 	github.com/BurntSushi/toml v0.2.1-0.20160707233338-ffaa107fbd88 // indirect
-	github.com/Sirupsen/logrus v0.10.1-0.20160601113210-f3cfb454f4c2
-	github.com/boltdb/bolt v1.3.1-0.20170131192018-e9cf4fae01b5
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/elazarl/goproxy v0.0.0-20210801061803-8e322dfb79c4 // indirect
 	github.com/fsnotify/fsnotify v1.3.1 // indirect
 	github.com/gorilla/context v0.0.0-20160525203319-aed02d124ae4 // indirect
-	github.com/gorilla/mux v0.0.0-20160605233521-9fa818a44c2b
-	github.com/hashicorp/go-cleanhttp v0.5.0
 	github.com/hashicorp/hcl v0.0.0-20160708141338-364df430845a // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/magiconair/properties v1.7.1-0.20160705171333-e2f061ecfdac // indirect
 	github.com/mitchellh/mapstructure v0.0.0-20160212031839-d2dd02622084 // indirect
 	github.com/moul/http2curl v0.0.0-20160520213128-b1479103caac // indirect
-	github.com/parnurzeal/gorequest v0.2.14-0.20160312085432-c4a74a6708c9
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/spf13/cast v0.0.0-20160314192028-27b586b42e29 // indirect
-	github.com/spf13/cobra v0.0.0-20160708202402-a272c3cbd5ff
 	github.com/spf13/jwalterweatherman v0.0.0-20160311093646-33c24e77fb80 // indirect
 	github.com/spf13/pflag v0.0.0-20160610190902-367864438f1b // indirect
-	github.com/spf13/viper v0.0.0-20160605220307-c1ccc378a054
-	github.com/stretchr/testify v1.2.3-0.20181014000028-04af85275a5c
-	github.com/vulcand/oxy v0.0.0-20160623194703-40720199a16c
+	golang.org/x/net v0.0.0-20190311183353-d8887717615a // indirect
+	golang.org/x/sys v0.6.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v2 v2.2.8 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,9 @@ github.com/vulcand/oxy v0.0.0-20160623194703-40720199a16c/go.mod h1:giFb8dicROVd
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a h1:oWX7TPOiFAMXLq8o0ikBYfCJVlRHBcsciT5bXOrH628=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
```
NAME              INSTALLED                           FIXED-IN                           TYPE       VULNERABILITY        SEVERITY                
apt               1.8.2.3                                                                deb        CVE-2011-3374        Negligible (suppressed)  
bash              5.0-4                                                                  deb        CVE-2019-18276       Negligible (suppressed)  
bash              5.0-4                               (won't fix)                        deb        CVE-2022-3715        High (suppressed)        
bsdutils          1:2.33.1-0.1                                                           deb        CVE-2022-0563        Negligible (suppressed)  
bsdutils          1:2.33.1-0.1                        (won't fix)                        deb        CVE-2021-37600       Low (suppressed)         
coreutils         8.30-3                                                                 deb        CVE-2017-18018       Negligible (suppressed)  
coreutils         8.30-3                              (won't fix)                        deb        CVE-2016-2781        Low (suppressed)         
e2fsprogs         1.44.5-1+deb10u3                    (won't fix)                        deb        CVE-2022-1304        High (suppressed)        
fdisk             2.33.1-0.1                                                             deb        CVE-2022-0563        Negligible (suppressed)  
fdisk             2.33.1-0.1                          (won't fix)                        deb        CVE-2021-37600       Low (suppressed)         
gcc-8-base        8.3.0-6                             (won't fix)                        deb        CVE-2018-12886       High (suppressed)        
gcc-8-base        8.3.0-6                             (won't fix)                        deb        CVE-2019-15847       High (suppressed)        
golang.org/x/sys  v0.0.0-20190215142949-d0b11bdaac8a  0.0.0-20220412211240-33da011f77ad  go-module  GHSA-p782-xgp4-8hr8  Medium (suppressed)      
gpgv              2.2.12-1+deb10u2                                                       deb        CVE-2022-3219        Negligible (suppressed)  
gpgv              2.2.12-1+deb10u2                    (won't fix)                        deb        CVE-2019-14855       Low (suppressed)         
libapt-pkg5.0     1.8.2.3                                                                deb        CVE-2011-3374        Negligible (suppressed)  
libblkid1         2.33.1-0.1                                                             deb        CVE-2022-0563        Negligible (suppressed)  
libblkid1         2.33.1-0.1                          (won't fix)                        deb        CVE-2021-37600       Low (suppressed)         
libc-bin          2.28-10+deb10u2                                                        deb        CVE-2010-4756        Negligible (suppressed)  
libc-bin          2.28-10+deb10u2                                                        deb        CVE-2018-20796       Negligible (suppressed)  
libc-bin          2.28-10+deb10u2                                                        deb        CVE-2019-1010022     Negligible (suppressed)  
libc-bin          2.28-10+deb10u2                                                        deb        CVE-2019-1010023     Negligible (suppressed)  
libc-bin          2.28-10+deb10u2                                                        deb        CVE-2019-1010024     Negligible (suppressed)  
libc-bin          2.28-10+deb10u2                                                        deb        CVE-2019-1010025     Negligible (suppressed)  
libc-bin          2.28-10+deb10u2                                                        deb        CVE-2019-9192        Negligible (suppressed)  
libc-bin          2.28-10+deb10u2                     (won't fix)                        deb        CVE-2020-1751        High (suppressed)        
libc6             2.28-10+deb10u2                                                        deb        CVE-2010-4756        Negligible (suppressed)  
libc6             2.28-10+deb10u2                                                        deb        CVE-2018-20796       Negligible (suppressed)  
libc6             2.28-10+deb10u2                                                        deb        CVE-2019-1010022     Negligible (suppressed)  
libc6             2.28-10+deb10u2                                                        deb        CVE-2019-1010023     Negligible (suppressed)  
libc6             2.28-10+deb10u2                                                        deb        CVE-2019-1010024     Negligible (suppressed)  
libc6             2.28-10+deb10u2                                                        deb        CVE-2019-1010025     Negligible (suppressed)  
libc6             2.28-10+deb10u2                                                        deb        CVE-2019-9192        Negligible (suppressed)  
libc6             2.28-10+deb10u2                     (won't fix)                        deb        CVE-2020-1751        High (suppressed)        
libcom-err2       1.44.5-1+deb10u3                    (won't fix)                        deb        CVE-2022-1304        High (suppressed)        
libdb5.3          5.3.28+dfsg1-0.5                    (won't fix)                        deb        CVE-2019-8457        Critical (suppressed)    
libext2fs2        1.44.5-1+deb10u3                    (won't fix)                        deb        CVE-2022-1304        High (suppressed)        
libfdisk1         2.33.1-0.1                                                             deb        CVE-2022-0563        Negligible (suppressed)  
libfdisk1         2.33.1-0.1                          (won't fix)                        deb        CVE-2021-37600       Low (suppressed)         
libgcc1           1:8.3.0-6                           (won't fix)                        deb        CVE-2018-12886       High (suppressed)        
libgcc1           1:8.3.0-6                           (won't fix)                        deb        CVE-2019-15847       High (suppressed)        
libgcrypt20       1.8.4-5+deb10u1                                                        deb        CVE-2018-6829        Negligible (suppressed)  
libgcrypt20       1.8.4-5+deb10u1                     (won't fix)                        deb        CVE-2019-13627       Medium (suppressed)      
libgcrypt20       1.8.4-5+deb10u1                     (won't fix)                        deb        CVE-2021-33560       High (suppressed)        
libgnutls30       3.6.7-4+deb10u9                                                        deb        CVE-2011-3389        Negligible (suppressed)  
libgnutls30       3.6.7-4+deb10u9                     3.6.7-4+deb10u10                   deb        CVE-2023-0361        High                     
libidn2-0         2.0.5-1+deb10u1                     (won't fix)                        deb        CVE-2019-12290       High (suppressed)        
liblz4-1          1.8.3-1+deb10u1                     (won't fix)                        deb        CVE-2019-17543       Low (suppressed)         
libmount1         2.33.1-0.1                                                             deb        CVE-2022-0563        Negligible (suppressed)  
libmount1         2.33.1-0.1                          (won't fix)                        deb        CVE-2021-37600       Low (suppressed)         
libncursesw6      6.1+20181013-2+deb10u3                                                 deb        CVE-2021-39537       Negligible (suppressed)  
libpcre3          2:8.39-12                                                              deb        CVE-2017-11164       Negligible (suppressed)  
libpcre3          2:8.39-12                                                              deb        CVE-2017-16231       Negligible (suppressed)  
libpcre3          2:8.39-12                                                              deb        CVE-2017-7245        Negligible (suppressed)  
libpcre3          2:8.39-12                                                              deb        CVE-2017-7246        Negligible (suppressed)  
libpcre3          2:8.39-12                                                              deb        CVE-2019-20838       Negligible (suppressed)  
libpcre3          2:8.39-12                           (won't fix)                        deb        CVE-2020-14155       Medium (suppressed)      
libseccomp2       2.3.3-4                                                                deb        CVE-2019-9893        Negligible (suppressed)  
libsepol1         2.8-1                               (won't fix)                        deb        CVE-2021-36084       Low (suppressed)         
libsepol1         2.8-1                               (won't fix)                        deb        CVE-2021-36085       Low (suppressed)         
libsepol1         2.8-1                               (won't fix)                        deb        CVE-2021-36086       Low (suppressed)         
libsepol1         2.8-1                               (won't fix)                        deb        CVE-2021-36087       Low (suppressed)         
libsmartcols1     2.33.1-0.1                                                             deb        CVE-2022-0563        Negligible (suppressed)  
libsmartcols1     2.33.1-0.1                          (won't fix)                        deb        CVE-2021-37600       Low (suppressed)         
libss2            1.44.5-1+deb10u3                    (won't fix)                        deb        CVE-2022-1304        High (suppressed)        
libssl1.1         1.1.1n-0+deb10u3                                                       deb        CVE-2007-6755        Negligible (suppressed)  
libssl1.1         1.1.1n-0+deb10u3                                                       deb        CVE-2010-0928        Negligible (suppressed)  
libssl1.1         1.1.1n-0+deb10u3                    1.1.1n-0+deb10u4                   deb        CVE-2022-2097        Medium                   
libssl1.1         1.1.1n-0+deb10u3                    1.1.1n-0+deb10u4                   deb        CVE-2022-4304        Medium                   
libssl1.1         1.1.1n-0+deb10u3                    1.1.1n-0+deb10u4                   deb        CVE-2022-4450        High                     
libssl1.1         1.1.1n-0+deb10u3                    1.1.1n-0+deb10u4                   deb        CVE-2023-0215        High                     
libssl1.1         1.1.1n-0+deb10u3                    1.1.1n-0+deb10u4                   deb        CVE-2023-0286        High                     
libstdc++6        8.3.0-6                             (won't fix)                        deb        CVE-2018-12886       High (suppressed)        
libstdc++6        8.3.0-6                             (won't fix)                        deb        CVE-2019-15847       High (suppressed)        
libsystemd0       241-7~deb10u8                                                          deb        CVE-2013-4392        Negligible (suppressed)  
libsystemd0       241-7~deb10u8                                                          deb        CVE-2019-20386       Negligible (suppressed)  
libsystemd0       241-7~deb10u8                                                          deb        CVE-2020-13529       Negligible (suppressed)  
libsystemd0       241-7~deb10u8                                                          deb        CVE-2023-26604       High (suppressed)        
libsystemd0       241-7~deb10u8                       (won't fix)                        deb        CVE-2019-3843        High (suppressed)        
libsystemd0       241-7~deb10u8                       (won't fix)                        deb        CVE-2019-3844        High (suppressed)        
libsystemd0       241-7~deb10u8                       (won't fix)                        deb        CVE-2021-3997        Medium (suppressed)      
libsystemd0       241-7~deb10u8                       (won't fix)                        deb        CVE-2022-3821        Medium (suppressed)      
libsystemd0       241-7~deb10u8                       (won't fix)                        deb        CVE-2022-4415        Medium (suppressed)      
libtasn1-6        4.13-3                                                                 deb        CVE-2018-1000654     Negligible (suppressed)  
libtasn1-6        4.13-3                              4.13-3+deb10u1                     deb        CVE-2021-46848       Critical                 
libtinfo6         6.1+20181013-2+deb10u3                                                 deb        CVE-2021-39537       Negligible (suppressed)  
libudev1          241-7~deb10u8                                                          deb        CVE-2013-4392        Negligible (suppressed)  
libudev1          241-7~deb10u8                                                          deb        CVE-2019-20386       Negligible (suppressed)  
libudev1          241-7~deb10u8                                                          deb        CVE-2020-13529       Negligible (suppressed)  
libudev1          241-7~deb10u8                                                          deb        CVE-2023-26604       High (suppressed)        
libudev1          241-7~deb10u8                       (won't fix)                        deb        CVE-2019-3843        High (suppressed)        
libudev1          241-7~deb10u8                       (won't fix)                        deb        CVE-2019-3844        High (suppressed)        
libudev1          241-7~deb10u8                       (won't fix)                        deb        CVE-2021-3997        Medium (suppressed)      
libudev1          241-7~deb10u8                       (won't fix)                        deb        CVE-2022-3821        Medium (suppressed)      
libudev1          241-7~deb10u8                       (won't fix)                        deb        CVE-2022-4415        Medium (suppressed)      
libuuid1          2.33.1-0.1                                                             deb        CVE-2022-0563        Negligible (suppressed)  
libuuid1          2.33.1-0.1                          (won't fix)                        deb        CVE-2021-37600       Low (suppressed)         
login             1:4.5-1.1                                                              deb        CVE-2007-5686        Negligible (suppressed)  
login             1:4.5-1.1                                                              deb        CVE-2013-4235        Negligible (suppressed)  
login             1:4.5-1.1                                                              deb        CVE-2019-19882       Negligible (suppressed)  
login             1:4.5-1.1                           (won't fix)                        deb        CVE-2018-7169        Low (suppressed)         
mount             2.33.1-0.1                                                             deb        CVE-2022-0563        Negligible (suppressed)  
mount             2.33.1-0.1                          (won't fix)                        deb        CVE-2021-37600       Low (suppressed)         
ncurses-base      6.1+20181013-2+deb10u3                                                 deb        CVE-2021-39537       Negligible (suppressed)  
ncurses-bin       6.1+20181013-2+deb10u3                                                 deb        CVE-2021-39537       Negligible (suppressed)  
openssl           1.1.1n-0+deb10u3                                                       deb        CVE-2007-6755        Negligible (suppressed)  
openssl           1.1.1n-0+deb10u3                                                       deb        CVE-2010-0928        Negligible (suppressed)  
openssl           1.1.1n-0+deb10u3                    1.1.1n-0+deb10u4                   deb        CVE-2022-2097        Medium                   
openssl           1.1.1n-0+deb10u3                    1.1.1n-0+deb10u4                   deb        CVE-2022-4304        Medium                   
openssl           1.1.1n-0+deb10u3                    1.1.1n-0+deb10u4                   deb        CVE-2022-4450        High                     
openssl           1.1.1n-0+deb10u3                    1.1.1n-0+deb10u4                   deb        CVE-2023-0215        High                     
openssl           1.1.1n-0+deb10u3                    1.1.1n-0+deb10u4                   deb        CVE-2023-0286        High                     
passwd            1:4.5-1.1                                                              deb        CVE-2007-5686        Negligible (suppressed)  
passwd            1:4.5-1.1                                                              deb        CVE-2013-4235        Negligible (suppressed)  
passwd            1:4.5-1.1                                                              deb        CVE-2019-19882       Negligible (suppressed)  
passwd            1:4.5-1.1                           (won't fix)                        deb        CVE-2018-7169        Low (suppressed)         
perl-base         5.28.1-6+deb10u1                                                       deb        CVE-2011-4116        Negligible (suppressed)  
perl-base         5.28.1-6+deb10u1                    (won't fix)                        deb        CVE-2020-16156       High (suppressed)        
tar               1.30+dfsg-6                                                            deb        CVE-2005-2541        Negligible (suppressed)  
tar               1.30+dfsg-6                                                            deb        CVE-2019-9923        Negligible (suppressed)  
tar               1.30+dfsg-6                                                            deb        CVE-2021-20193       Negligible (suppressed)  
tar               1.30+dfsg-6                                                            deb        CVE-2022-48303       Negligible (suppressed)  
util-linux        2.33.1-0.1                                                             deb        CVE-2022-0563        Negligible (suppressed)  
util-linux        2.33.1-0.1                          (won't fix)                        deb        CVE-2021-37600       Low (suppressed)     
```