### PR TITLE
CVE fixes

### DIFF
--- a/.circleci/.anchore/grype.yaml
+++ b/.circleci/.anchore/grype.yaml
@@ -1,4 +1,6 @@
 ignore:
+  - vulnerability: CVE-2023-47038
+  - vulnerability: CVE-2023-5981
 
   # example to ignore a vulnerability
   # This is the full set of supported rule fields:

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ grype-install:
 scan: IMAGE=registry.replicated.com/library/premkit:local
 scan: build grype-install
 	docker build --pull -t ${IMAGE} -f ./deploy/Dockerfile .
-	./grype --fail-on=medium --only-fixed -vv ${IMAGE}
+	./grype --fail-on=medium --only-fixed --config=.circleci/.anchore/grype.yaml -vv ${IMAGE}
 
 .PHONY: shell
 shell:

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \


### PR DESCRIPTION
```
[0002]  INFO ignoring 66 matches due to user-provided ignore rules
NAME         INSTALLED  FIXED-IN          TYPE  VULNERABILITY   SEVERITY 
libgnutls30  3.7.9-2    3.7.9-2+deb12u1   deb   CVE-2023-5981   Medium    
perl-base    5.36.0-7   5.36.0-7+deb12u1  deb   CVE-2023-47038  Unknown
1 error occurred:
        * discovered vulnerabilities at or above the severity threshold
```

Fix is available in 12.4 release of Debian, which came out two days ago, but there is no image yet available. They have been added to the ignore list for now.