### PR TITLE
Run upgrade to resolve CVE-2025-0395

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bookworm-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     ca-certificates \
     \
     \


### PR DESCRIPTION
`apt-get upgrade` increases image size from 96.3MB to 114MB